### PR TITLE
add-threat-modeling-links

### DIFF
--- a/DevSecOps/SDLC/Threat Modeling/articles.md
+++ b/DevSecOps/SDLC/Threat Modeling/articles.md
@@ -24,5 +24,4 @@
     - REPUDIATION OF ACTION [link](https://martinfowler.com/articles/agile-threat-modelling/Repudiation_Of_Action-STRIDE_Threat_Modelling_Card.pdf)
     - INFORMATION DISCLOSURE [link](https://martinfowler.com/articles/agile-threat-modelling/Information_Disclosure-STRIDE_Threat_Modelling_Card.pdf)
     - DENIAL OF SERVICE [link](https://martinfowler.com/articles/agile-threat-modelling/Denial_of_Service-STRIDE_Threat_Modelling_Card.pdf)
-    - ELEVATION OF PRIVILEGE [link](https://martinfowler.com/articles/
-    agile-threat-modelling/Elevation_Of_Privilege-STRIDE_Threat_Modelling_Card.pdf)
+    - ELEVATION OF PRIVILEGE [link](https://martinfowler.com/articles/agile-threat-modelling/Elevation_Of_Privilege-STRIDE_Threat_Modelling_Card.pdf)

--- a/DevSecOps/SDLC/Threat Modeling/articles.md
+++ b/DevSecOps/SDLC/Threat Modeling/articles.md
@@ -4,3 +4,25 @@
 -----
 
 1. Securing: Modelowanie zagrożeń - [link](https://www.securing.pl/pl/service/modelowanie-zagrozen/)
+
+1. Threat Modeling Manifesto - [link](https://www.threatmodelingmanifesto.org/)
+
+1. OWASP Threat Modeling Cheat Sheet - [link](https://cheatsheetseries.owasp.org/cheatsheets/Threat_Modeling_Cheat_Sheet.html)
+
+1. Awesome Threat Modeling Github list of Threat Modelling Resources - [link](https://github.com/hysnsec/awesome-threat-modelling)
+
+1. SEI Threat Modeling: 12 Available Methods - [link](https://insights.sei.cmu.edu/blog/threat-modeling-12-available-methods/)
+    - Table with threat modeling methods [link](https://insights.sei.cmu.edu/media/images/Threat20Modeling20Table.original.jpg)
+
+1. STRIDE model - [link](https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool-threats)
+
+1. Matrin Fowler - Agile Threat Modeling - [link](https://martinfowler.com/articles/agile-threat-modelling.html)
+
+1. Martin Fowler STRIDE Cheat Sheets:
+    - SPOOFED IDENTITY [link](https://martinfowler.com/articles/agile-threat-modelling/Spoofed_Identity-STRIDE_Threat_Modelling_Card.pdf)
+    - TAMPERING WITH INPUT [link](https://martinfowler.com/articles/agile-threat-modelling/Tampering_with_Input-STRIDE_Threat_Modelling_Card.pdf)
+    - REPUDIATION OF ACTION [link](https://martinfowler.com/articles/agile-threat-modelling/Repudiation_Of_Action-STRIDE_Threat_Modelling_Card.pdf)
+    - INFORMATION DISCLOSURE [link](https://martinfowler.com/articles/agile-threat-modelling/Information_Disclosure-STRIDE_Threat_Modelling_Card.pdf)
+    - DENIAL OF SERVICE [link](https://martinfowler.com/articles/agile-threat-modelling/Denial_of_Service-STRIDE_Threat_Modelling_Card.pdf)
+    - ELEVATION OF PRIVILEGE [link](https://martinfowler.com/articles/
+    agile-threat-modelling/Elevation_Of_Privilege-STRIDE_Threat_Modelling_Card.pdf)

--- a/DevSecOps/SDLC/Threat Modeling/tools.md
+++ b/DevSecOps/SDLC/Threat Modeling/tools.md
@@ -3,4 +3,12 @@
 ## Threat Modeling
 -----
 
-It's empty here for now. Come back in a while and if you have links, let me know!
+There are specialized free tools for Threat Modeling:
+
+1. OWASP Threat Modelling Dragon [link](https://owasp.org/www-project-threat-dragon/)
+
+1. Microsoft Threat Modeling Tool [link](https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool)
+
+But for Threat Modeling we can use each 'whiteboard' tool e.g.:
+
+1. draw.io [link](https://app.diagrams.net/)

--- a/DevSecOps/SDLC/Threat Modeling/videos.md
+++ b/DevSecOps/SDLC/Threat Modeling/videos.md
@@ -3,4 +3,6 @@
 ## Threat Modeling
 -----
 
-It's empty here for now. Come back in a while and if you have links, let me know!
+1. Adam Shostack - Worlds Shortest Threat Modeling Course YT playlist - [link](https://www.youtube.com/watch?v=2pvprvsr1lo&list=PLCVhBqLDKoOOZqKt74QI4pbDUnXSQo0nf&index=1)
+
+1. MIT Computer Systems Security Session 1: Threat Models - [link](https://ocw.mit.edu/courses/6-858-computer-systems-security-fall-2014/resources/lecture-1-introduction-threat-models/)


### PR DESCRIPTION
Hi,
I would like to add some links to Threat Modeling. Mostly about STRIDE methodology.