### PR TITLE
Add Huntr - platforms section

### DIFF
--- a/Bug Bounty/platforms.md
+++ b/Bug Bounty/platforms.md
@@ -12,3 +12,4 @@
 7. Bug Bounty Project Discovery - [link](https://chaos.projectdiscovery.io/#/)
 8. HACKYX - [link](https://hackyx.io/)
 9. Yogosha - [link](https://yogosha.com/hackers/join-yogosha-strike-force/)
+10. Huntr - [link](https://huntr.com/)


### PR DESCRIPTION
Add Huntr (previously known as huntr.dev) platform