### PR TITLE
Add Google Bug Hunters

### DIFF
--- a/Bug Bounty/platforms.md
+++ b/Bug Bounty/platforms.md
@@ -13,3 +13,4 @@
 8. HACKYX - [link](https://hackyx.io/)
 9. Yogosha - [link](https://yogosha.com/hackers/join-yogosha-strike-force/)
 10. Huntr - [link](https://huntr.com/)
+11. Google Bug Hunters - [link](https://bughunters.google.com/)


### PR DESCRIPTION
Bug Bounty platform focused on Google / Alphabet products.

"Google Bug Hunters is aimed at external security researchers who want to contribute to keeping Google products safe and secure."

Best wishes,