### PR TITLE
Add MediaWiki BBP/VDP

### DIFF
--- a/Bug Bounty/platforms.md
+++ b/Bug Bounty/platforms.md
@@ -14,3 +14,4 @@
 9. Yogosha - [link](https://yogosha.com/hackers/join-yogosha-strike-force/)
 10. Huntr - [link](https://huntr.com/)
 11. Google Bug Hunters - [link](https://bughunters.google.com/)
+12. MediaWiki - [link](https://security.wikimedia.org/bug-bounty/)


### PR DESCRIPTION
MediaWiki is free and open-source wiki software, primarily known for powering Wikipedia and other Wikimedia projects.

Wikipedia.org is the fourth most visited website globally. It is consistently ranked among the top websites by monthly traffic, with billions of visits.

Reporting via Phabricator https://www.mediawiki.org/wiki/Phabricator (recommended by me)

- Focused on MediaWiki products.

Best,