### PR TITLE
Add The Mozilla Security Bug Bounty Program

### DIFF
--- a/Bug Bounty/platforms.md
+++ b/Bug Bounty/platforms.md
@@ -15,3 +15,4 @@
 10. Huntr - [link](https://huntr.com/)
 11. Google Bug Hunters - [link](https://bughunters.google.com/)
 12. MediaWiki - [link](https://security.wikimedia.org/bug-bounty/)
+13. Mozilla Security Bug Bounty Program - [link](https://www.mozilla.org/en-US/security/bug-bounty/)


### PR DESCRIPTION
Platform focused on Mozilla products.

Since 2023/2024 'Web Bug Bounty' via their H1, but 'Client Bug Bounty' still exist there.

"The Mozilla Security Bug Bounty Program is designed to encourage security research in Mozilla software and to reward those who help us make the internet a safer place."

Best,