### PR TITLE
 Add tool to Web Hacking Tools

### DIFF
--- a/Red Team/Web Hacking/tools.md
+++ b/Red Team/Web Hacking/tools.md
@@ -91,3 +91,4 @@
 -  Noir - Attack surface detector that identifies endpoints by static analysis - [link](https://github.com/owasp-noir/noir)
 -  fuzzuli - fuzzuli is a url fuzzing tool that aims to find critical backup files by creating a dynamic wordlist based on the domain. - [link](https://github.com/musana/fuzzuli)
 -  Subdomain Finder - another tool used to find the subdomains of a given domain - [link](https://subdomainfinder.c99.nl/)
+-  CorsOne: Fast, Accurate, and Comprehensive CORS Misconfiguration Detection - [link](https://github.com/omranisecurity/CorsOne)


### PR DESCRIPTION
Adds [CorsOne](https://github.com/omranisecurity/CorsOne), a fast and accurate tool for detecting CORS misconfigurations, to the web hacking tools list.