### PR TITLE
Add browser-local metadata viewer to OSINT tools

### DIFF
--- a/Red Team/OSINT/tools.md
+++ b/Red Team/OSINT/tools.md
@@ -39,6 +39,7 @@
 -  Search by email or phone number over 200 websites. Generate cool report. (Needs free account and credits) - [link](https://osint.industries/)
 -  Photo search tool using face to find social media accounts of people - [link](https://facecheck.id)
 -  Easy to use photo forensics tool - [link](https://fotoforensics.com/)
+- Browser-local EXIF/IPTC/XMP metadata viewer for images and documents; corroborate metadata because it can be edited or removed - [link](https://metadataremover.ai/metadata-viewer)
 -  Surface, deep and dark web intelligence - [link](https://sosintel.co.uk)
 -  Powerfull, easy to use darkweb engine with browser sandbox built-in - [link](https://bluestoneanalytics.com/darkblue)
 -  Darkweb intelligence multi tool - [link](https://www.darkowl.com/)


### PR DESCRIPTION
## What changed
- Added a browser-local EXIF/IPTC/XMP metadata viewer beside the existing photo-forensics tool.
- Included a reminder that metadata can be edited or removed and should be corroborated.

## Fit
The tool is free to use without an account and directly supports the OSINT image/file-analysis workflow in this page.

Disclosure: I maintain Metadata Remover. This is a transparent resource suggestion; no payment or reciprocal link is requested.